### PR TITLE
Optimize ParquetPublisher and make ParquetSubscriber safer

### DIFF
--- a/parquet/src/main/scala/monix/connect/parquet/Parquet.scala
+++ b/parquet/src/main/scala/monix/connect/parquet/Parquet.scala
@@ -48,8 +48,7 @@ object Parquet {
     * @tparam T A hinder kinded type that represents element type of the parquet file to be read.
     * @return All the elements of type [[T]] the specified parquet file as [[Observable]]
     */
-  def reader[T](reader: ParquetReader[T])(implicit scheduler: Scheduler): Observable[T] = {
-    ParquetPublisher(reader).create
+  def fromReaderUnsafe[T](reader: ParquetReader[T])(implicit scheduler: Scheduler): Observable[T] = {
+    new ParquetPublisher[T](reader)
   }
-
 }

--- a/parquet/src/main/scala/monix/connect/parquet/Parquet.scala
+++ b/parquet/src/main/scala/monix/connect/parquet/Parquet.scala
@@ -29,12 +29,11 @@ object Parquet {
     * @param writer The apache hadoop generic implementation of a parquet writer.
     *               See the following known implementations of [[ParquetWriter]] for avro and protobuf respectively:
     *               [[org.apache.parquet.avro.AvroParquetWriter]], [[org.apache.parquet.proto.ProtoParquetWriter]].
-    * @param scheduler An implicit [[Scheduler]] instance to be in the scope of the call.
     * @tparam T A hinder kinded type that represents the element type of the parquet file to be written.
     * @return A [[Consumer]] that expects records of type [[T]] to be passed and materializes to [[Long]]
     *         that represents the number of elements written.
     */
-  def writer[T](writer: ParquetWriter[T])(implicit scheduler: Scheduler): Consumer[T, Long] = {
+  def writer[T](writer: ParquetWriter[T]): Consumer[T, Long] = {
     new ParquetSubscriber[T](writer)
   }
 
@@ -44,11 +43,10 @@ object Parquet {
     * @param reader The apache hadoop generic implementation of a parquet reader.
     *               See the following known implementations of [[ParquetWriter]] for avro and protobuf respectively:
     *               [[org.apache.parquet.avro.AvroParquetWriter]], [[org.apache.parquet.proto.ProtoParquetWriter]].
-    * @param scheduler An implicit [[Scheduler]] instance to be in the scope of the call.
     * @tparam T A hinder kinded type that represents element type of the parquet file to be read.
     * @return All the elements of type [[T]] the specified parquet file as [[Observable]]
     */
-  def fromReaderUnsafe[T](reader: ParquetReader[T])(implicit scheduler: Scheduler): Observable[T] = {
+  def fromReaderUnsafe[T](reader: ParquetReader[T]): Observable[T] = {
     new ParquetPublisher[T](reader)
   }
 }

--- a/parquet/src/main/scala/monix/connect/parquet/ParquetPublisher.scala
+++ b/parquet/src/main/scala/monix/connect/parquet/ParquetPublisher.scala
@@ -17,50 +17,70 @@
 
 package monix.connect.parquet
 
-import monix.eval.Task
-import monix.reactive.{Observable, OverflowStrategy}
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.cancelables.BooleanCancelable
+import monix.execution.{Ack, Cancelable, ExecutionModel, Scheduler}
+import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 import org.apache.parquet.hadoop.ParquetReader
-import monix.execution.Ack
+
+import scala.annotation.tailrec
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 /**
   * The implementation of a reactive parquet publisher.
   * @param reader The apache hadoop generic implementation of a parquet reader.
   */
-private[parquet] class ParquetPublisher[T](reader: ParquetReader[T]) {
+private[parquet] final class ParquetPublisher[T](reader: ParquetReader[T]) extends Observable[T] {
 
-  /**
-    * A recursive function that keeps reading records from a parquet file until the last one.
-    * @param sub The upstream subscriber to feed with the read records.
-    */
-  private def readRecords(sub: Subscriber[T]): Task[Unit] = {
-    val t = Task(reader.read())
-    t.redeemWith(
-      ex => Task(sub.onError(ex)),
-      r => {
-        if (r != null) {
-          Task.deferFuture(sub.onNext(r)).flatMap {
-            case Ack.Continue => readRecords(sub)
-            case Ack.Stop => Task.unit
-          }
-        } else {
-          sub.onComplete()
-          Task.unit
-        }
-      }
-    )
+  def unsafeSubscribeFn(subscriber: Subscriber[T]): Cancelable = {
+    val s = subscriber.scheduler
+    val cancelable = BooleanCancelable()
+    fastLoop(subscriber, cancelable, s.executionModel, 0)(s)
+    cancelable
   }
 
-  /**
-    * Parquet reader [[Observable]] builder.
-    */
-  val create: Observable[T] =
-    Observable.create(OverflowStrategy.Unbounded) { sub => readRecords(sub).runToFuture(sub.scheduler) }
-}
+  @tailrec
+  def fastLoop(o: Subscriber[T], c: BooleanCancelable, em: ExecutionModel, syncIndex: Int)(
+    implicit
+    s: Scheduler): Unit = {
 
-/**
-  * Companion object builder for [[ParquetPublisher]].
-  */
-object ParquetPublisher {
-  private[parquet] def apply[T](reader: ParquetReader[T]): ParquetPublisher[T] = new ParquetPublisher(reader)
+    val ack =
+      try {
+        val r = reader.read()
+        if (r != null) o.onNext(r)
+        else {
+          o.onComplete()
+          Stop
+        }
+      } catch {
+        case ex if NonFatal(ex) =>
+          Future.failed(ex)
+      }
+
+    val nextIndex =
+      if (ack == Continue) em.nextFrameIndex(syncIndex)
+      else if (ack == Stop) -1
+      else 0
+
+    if (nextIndex > 0)
+      fastLoop(o, c, em, nextIndex)
+    else if (nextIndex == 0 && !c.isCanceled)
+      reschedule(ack, o, c, em)
+  }
+
+  def reschedule(ack: Future[Ack], o: Subscriber[T], c: BooleanCancelable, em: ExecutionModel)(
+    implicit
+    s: Scheduler): Unit =
+    ack.onComplete {
+      case Success(success) =>
+        if (success == Continue) fastLoop(o, c, em, 0)
+      case Failure(ex) =>
+        o.onError(ex)
+        s.reportFailure(ex)
+      case _ =>
+        () // this was a Stop, do nothing
+    }
 }

--- a/parquet/src/test/scala/monix/connect/parquet/AvroParquetSpec.scala
+++ b/parquet/src/test/scala/monix/connect/parquet/AvroParquetSpec.scala
@@ -61,7 +61,7 @@ class AvroParquetSpec extends AnyWordSpecLike with Matchers with AvroParquetFixt
         .runSyncUnsafe()
 
       //when
-      val result: List[GenericRecord] = Parquet.reader(avroParquetReader(file, conf)).toListL.runSyncUnsafe()
+      val result: List[GenericRecord] = Parquet.fromReaderUnsafe(avroParquetReader(file, conf)).toListL.runSyncUnsafe()
 
       //then
       result.length shouldEqual n

--- a/parquet/src/test/scala/monix/connect/parquet/ProtoParquetSpec.scala
+++ b/parquet/src/test/scala/monix/connect/parquet/ProtoParquetSpec.scala
@@ -92,7 +92,7 @@ class ProtoParquetSpec
         .runSyncUnsafe()
 
       //when
-      val l: List[ProtoDoc.Builder] = Parquet.reader(protoParquetReader(file, conf)).toListL.runSyncUnsafe()
+      val l: List[ProtoDoc.Builder] = Parquet.fromReaderUnsafe(protoParquetReader(file, conf)).toListL.runSyncUnsafe()
 
       //then
       l.length shouldEqual 1


### PR DESCRIPTION
I have reimplemented ParquetPublisher to be similar to `Observable.repeatEval`.
I didn't do any benchmarks but I'm pretty sure it will be faster because it doesn't have to go through the `Task` Run-loop at all.