### PR TITLE
Feature/from config overloaded

### DIFF
--- a/aws-auth/src/main/resources/reference.conf
+++ b/aws-auth/src/main/resources/reference.conf
@@ -52,4 +52,28 @@
 
   }
 
+  // Camel case fallback
+  monixAws: {
+    credentials {
+      provider: "default"
+    }
+    region: "eu-west-1"
+  }
+
+  // Snake case fallback
+  monix_aws: {
+    credentials {
+      provider: "default"
+    }
+    region: "eu-west-1"
+  }
+
+  // Pascal case fallback
+  MonixAws: {
+    credentials {
+      provider: "default"
+    }
+    region: "eu-west-1"
+  }
+
 }

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/AwsCredentialsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/AwsCredentialsConf.scala
@@ -33,22 +33,22 @@ import software.amazon.awssdk.auth.credentials.{
 
 @InternalApi
 private[connect] final case class AwsCredentialsConf(
-  provider: Provider.Type,
+  provider: Providers.Provider,
   profileName: Option[String],
   static: Option[StaticCredentialsConf]) {
   val credentialsProvider: AwsCredentialsProvider = {
     provider match {
-      case Provider.Anonymous => AnonymousCredentialsProvider.create()
-      case Provider.Default => DefaultCredentialsProvider.create()
-      case Provider.Environment => EnvironmentVariableCredentialsProvider.create()
-      case Provider.Instance => InstanceProfileCredentialsProvider.create()
-      case Provider.Profile => {
+      case Providers.Anonymous => AnonymousCredentialsProvider.create()
+      case Providers.Default => DefaultCredentialsProvider.create()
+      case Providers.Environment => EnvironmentVariableCredentialsProvider.create()
+      case Providers.Instance => InstanceProfileCredentialsProvider.create()
+      case Providers.Profile => {
         profileName match {
           case Some(name) => ProfileCredentialsProvider.create(name)
           case None => ProfileCredentialsProvider.create()
         }
       }
-      case Provider.Static =>
+      case Providers.Static =>
         static match {
           case Some(creeds) =>
             StaticCredentialsProvider.create {
@@ -59,7 +59,7 @@ private[connect] final case class AwsCredentialsConf(
             }
           case None => DefaultCredentialsProvider.create()
         }
-      case Provider.System => SystemPropertyCredentialsProvider.create()
+      case Providers.System => SystemPropertyCredentialsProvider.create()
       case _ => DefaultCredentialsProvider.create()
     }
   }

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/HttpClientConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/HttpClientConf.scala
@@ -17,11 +17,9 @@
 
 package monix.connect.aws.auth
 
-import monix.execution.internal.InternalApi
 import scala.concurrent.duration.FiniteDuration
 
-@InternalApi
-private[connect] final case class HttpClientConf(
+final case class HttpClientConf(
   maxConcurrency: Option[Int],
   maxPendingConnectionAcquires: Option[Int],
   connectionAcquisitionTimeout: Option[FiniteDuration],

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
@@ -18,40 +18,80 @@
 package monix.connect.aws.auth
 
 import monix.eval.Task
-import monix.execution.annotations.UnsafeBecauseImpure
-import monix.execution.internal.InternalApi
 import software.amazon.awssdk.regions.Region
 import pureconfig._
 import pureconfig.error.{ConfigReaderException, ConfigReaderFailures}
+import pureconfig.generic.ProductHint
 import pureconfig.generic.auto._
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 import java.net.URI
 
-@InternalApi
-private[connect] final case class MonixAwsConf(
-  region: Region,
-  credentials: AwsCredentialsProvider,
-  endpoint: Option[URI],
-  httpClient: Option[HttpClientConf])
+/**
+  * Represents the aws configuration that will be used/needed by
+  * the downstream monix aws dependencies (dynamo, s3, sqs).
+  *
+  * ==Example==
+  * {{{
+  *   import monix.connect.aws.auth.MonixAwsConf
+  *
+  *    // given that there is an `application.conf` file
+  *    // under resources folder that looks like below.
+  *   /**
+  *    * {
+  *    *    monix-aws: {
+  *    *      credentials {
+  *    *        provider: "default"
+  *    *      }
+  *    *      region: "eu-west-1"
+  *    *      endpoint: "localhost:4566"
+  *    *    }
+  *    * }
+  *    */
+  *
+  *   // to then read it
+  *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load
+  * }}}
+  *
+  * @param region the AWS region Anonymous
+  * @param credentialsProvider the credentials provider of type [[Providers.Provider]]
+  * @param endpoint optional config representing the AWS endpoint
+  * @param httpClient optional http configurations like maxConcurrency,
+  *                   connectionTimeToLive, connectionMaxIdleTime,
+  *                   read and write timeouts, etc.
+  */
+case class MonixAwsConf private (region: Region,
+                                 credentialsProvider: AwsCredentialsProvider,
+                                 endpoint: Option[URI],
+                                 httpClient: Option[HttpClientConf])
 
-@InternalApi
-private[connect] object MonixAwsConf {
-
-  implicit val credentialsProviderReader: ConfigReader[AwsCredentialsProvider] =
-    ConfigReader[AwsCredentialsConf].map { credentialsConf => credentialsConf.credentialsProvider }
-  implicit val providerReader: ConfigReader[Provider.Type] = ConfigReader[String].map(Provider.fromString)
-  implicit val regionReader: ConfigReader[Region] = ConfigReader[String].map(Region.of)
-  implicit val uriReader: ConfigReader[URI] = ConfigReader[String].map(URI.create)
+object MonixAwsConf {
 
   private[auth] final case class AppConf(monixAws: MonixAwsConf)
 
-  @UnsafeBecauseImpure
-  val loadOrThrow: MonixAwsConf = ConfigSource.default.loadOrThrow[AppConf].monixAws
+  implicit val credentialsProviderReader: ConfigReader[AwsCredentialsProvider] =
+    ConfigReader[AwsCredentialsConf].map(_.credentialsProvider)
+  implicit val providerReader: ConfigReader[Providers.Provider] = ConfigReader[String].map(Providers.fromString)
+  implicit val regionReader: ConfigReader[Region] = ConfigReader[String].map(Region.of)
+  implicit val uriReader: ConfigReader[URI] = ConfigReader[String].map(URI.create)
 
-  val load: Task[MonixAwsConf] = Task
-    .fromEither[ConfigReaderFailures, AppConf] { failures => new ConfigReaderException(failures) }(
-      ConfigSource.default.load[AppConf])
-    .map(_.monixAws)
+  /**
+    * Loads the aws auth configuration from the config file with the specified naming
+    * convention, being [[KebabCase]] the default one.
+    *
+    * It overwrites the defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
+    *
+    * @param namingConvention the name convention to read the data from the config file.
+    *
+    */
+  def load(namingConvention: NamingConvention = KebabCase): Task[MonixAwsConf] = {
+    implicit val hint: ProductHint[MonixAwsConf] = ProductHint(ConfigFieldMapping(namingConvention, namingConvention), useDefaultArgs = true, allowUnknownKeys = true)
+    Task
+      .fromEither[ConfigReaderFailures, AppConf] { ConfigReaderException(_) }(
+        ConfigSource.default.load[AppConf])
+      .map(_.monixAws)
+  }
+
 
 }

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
@@ -62,7 +62,7 @@ import java.net.URI
   *                   connectionTimeToLive, connectionMaxIdleTime,
   *                   read and write timeouts, etc.
   */
-case class MonixAwsConf private (
+final case class MonixAwsConf private (
   region: Region,
   credentials: AwsCredentialsProvider,
   endpoint: Option[URI],
@@ -79,6 +79,7 @@ object MonixAwsConf {
   implicit val uriReader: ConfigReader[URI] = ConfigReader[String].map(URI.create)
   val customHint: NamingConvention => ProductHint[AppConf] = namingConvention =>
     ProductHint(ConfigFieldMapping(CamelCase, namingConvention), useDefaultArgs = false, allowUnknownKeys = true)
+
   /**
     * Loads the aws auth configuration from the config file with the specified naming
     * convention, being [[KebabCase]] the default one.

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/MonixAwsConf.scala
@@ -60,10 +60,11 @@ import java.net.URI
   *                   connectionTimeToLive, connectionMaxIdleTime,
   *                   read and write timeouts, etc.
   */
-case class MonixAwsConf private (region: Region,
-                                 credentialsProvider: AwsCredentialsProvider,
-                                 endpoint: Option[URI],
-                                 httpClient: Option[HttpClientConf])
+case class MonixAwsConf private (
+  region: Region,
+  credentialsProvider: AwsCredentialsProvider,
+  endpoint: Option[URI],
+  httpClient: Option[HttpClientConf])
 
 object MonixAwsConf {
 
@@ -86,12 +87,13 @@ object MonixAwsConf {
     *
     */
   def load(namingConvention: NamingConvention = KebabCase): Task[MonixAwsConf] = {
-    implicit val hint: ProductHint[MonixAwsConf] = ProductHint(ConfigFieldMapping(namingConvention, namingConvention), useDefaultArgs = true, allowUnknownKeys = true)
+    implicit val hint: ProductHint[MonixAwsConf] = ProductHint(
+      ConfigFieldMapping(namingConvention, namingConvention),
+      useDefaultArgs = true,
+      allowUnknownKeys = true)
     Task
-      .fromEither[ConfigReaderFailures, AppConf] { ConfigReaderException(_) }(
-        ConfigSource.default.load[AppConf])
+      .fromEither[ConfigReaderFailures, AppConf] { ConfigReaderException(_) }(ConfigSource.default.load[AppConf])
       .map(_.monixAws)
   }
-
 
 }

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/Provider.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/Provider.scala
@@ -20,12 +20,12 @@ package monix.connect.aws.auth
 import monix.execution.internal.InternalApi
 
 @InternalApi
-private[connect] object Provider extends Enumeration {
+private[connect] object Providers extends Enumeration {
 
-  type Type = Value
+  type Provider = Value
   val Anonymous, Default, Environment, Instance, System, Profile, Static = Value
 
-  def fromString(str: String): Provider.Value = {
+  def fromString(str: String): Providers.Provider = {
     str.toLowerCase match {
       case "anonymous" => Anonymous
       case "default" => Default

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/StaticCredentialsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/StaticCredentialsConf.scala
@@ -17,7 +17,4 @@
 
 package monix.connect.aws.auth
 
-final case class StaticCredentialsConf(
-  accessKeyId: String,
-  secretAccessKey: String,
-  sessionToken: Option[String])
+final case class StaticCredentialsConf(accessKeyId: String, secretAccessKey: String, sessionToken: Option[String])

--- a/aws-auth/src/main/scala/monix/connect.aws.auth/StaticCredentialsConf.scala
+++ b/aws-auth/src/main/scala/monix/connect.aws.auth/StaticCredentialsConf.scala
@@ -17,10 +17,7 @@
 
 package monix.connect.aws.auth
 
-import monix.execution.internal.InternalApi
-
-@InternalApi
-private[connect] final case class StaticCredentialsConf(
+final case class StaticCredentialsConf(
   accessKeyId: String,
   secretAccessKey: String,
   sessionToken: Option[String])

--- a/aws-auth/src/test/resources/PascalCase.conf
+++ b/aws-auth/src/test/resources/PascalCase.conf
@@ -1,0 +1,7 @@
+ MonixAws: {
+   credentials {
+      provider: "default"
+   }
+   region: "eu-west-1"
+   endpoint: "PascalCase:12345"
+ }

--- a/aws-auth/src/test/resources/camelCase.conf
+++ b/aws-auth/src/test/resources/camelCase.conf
@@ -1,0 +1,7 @@
+ monixAws: {
+   credentials {
+      provider: "default"
+   }
+   region: "eu-west-1"
+   endpoint: "camelCase:12345"
+ }

--- a/aws-auth/src/test/resources/kebab-case.conf
+++ b/aws-auth/src/test/resources/kebab-case.conf
@@ -1,0 +1,7 @@
+ monix-aws: {
+   credentials {
+      provider: "default"
+   }
+   region: "eu-west-1"
+   endpoint: "kebab-case:12345"
+ }

--- a/aws-auth/src/test/resources/reference.conf
+++ b/aws-auth/src/test/resources/reference.conf
@@ -1,55 +1,9 @@
 {
-
   monix-aws: {
-
     credentials {
-
-      // Required - Specifies the aws credentials provider
-      // Posible values: [anonymous, default, environment, instance, system, profile, static]
       provider: "default"
-
-      // Optional - settings that only applies when `provider` is set to 'static'.
-      //
-      // If that's the case, `acces-key-id` and `secret-access-key` to create basic credentials:
-      // `software.amazon.awssdk.auth.credentials.AwsBasicCredentials`
-      //
-      // On the other hand, if the optional value `secret-access-key` is defined, it will use session credentials:
-      // `software.amazon.awssdk.auth.credentials.SessionStaticCredentialsProvider`
-      // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSSessionCredentials.html
-      //
-      # static {
-      #
-      #  // Required - within static settings.
-      #  access-key-id: ""
-      #  // Required - within static settings.
-      #
-      #  secret-access-key: ""
-      #
-      #  // Optional - when defined, will create `SessionStaticCredentialsProvider`
-      #  session-token: ""
-      #
-      # }
     }
-
-    // Required - Indicates the AWS region, should be in lowercase and use hyphens.
-    // Just like using `software.amazon.awssdk.regions.Region.of(_)`
-    // Examples: [ap-south-1, us-gov-east-1, af-south-1, eu-west-2, aws-global]
     region: "eu-west-1"
-
-    // Optional - string to overrides endpoint url
-    # endpoint: "localhost:4566"
-
-    // Optional - settings for the underlying async http client
-    # http-client: {
-    #   max-concurrency: 10
-    #   max-pending-connection-acquires: 1000
-    #   connection-acquisition-timeout: 2 minutes
-    #   connection-time-to-live: 1 minute
-    #   use-idle-connection-reaper: false
-    #   read-timeout: 100 seconds
-    #   write-timeout: 100 seconds
-    # }
-
+    endpoint: "localhost:4566"
   }
-
 }

--- a/aws-auth/src/test/resources/reference.conf
+++ b/aws-auth/src/test/resources/reference.conf
@@ -1,9 +1,50 @@
-{
-  monix-aws: {
+monix-aws: {
+
     credentials {
+
+      // Required - Specifies the aws credentials provider
+      // Posible values: [anonymous, default, environment, instance, system, profile, static]
       provider: "default"
+
+      // Optional - settings that only applies when `provider` is set to 'static'.
+      //
+      // If that's the case, `acces-key-id` and `secret-access-key` to create basic credentials:
+      // `software.amazon.awssdk.auth.credentials.AwsBasicCredentials`
+      //
+      // On the other hand, if the optional value `secret-access-key` is defined, it will use session credentials:
+      // `software.amazon.awssdk.auth.credentials.SessionStaticCredentialsProvider`
+      // [[https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSSessionCredentials.html]]
+      //
+      # static {
+      #
+      #  // Required - within static settings.
+      #  access-key-id: ""
+      #
+      #  // Required - within static settings.
+      #  secret-access-key: ""
+      #
+      #  // Optional - when defined, will create `SessionStaticCredentialsProvider`
+      #  session-token: ""
+      #
+      # }
     }
+
+    // Required - Indicates the AWS region, should be in lowercase and use hyphens.
+    // Just like using `software.amazon.awssdk.regions.Region.of(_)`
+    // Examples: [ap-south-1, us-gov-east-1, af-south-1, eu-west-2, aws-global]
     region: "eu-west-1"
+
+    // Optional - string to overrides endpoint url
     endpoint: "localhost:4566"
-  }
+
+    // Optional - settings for the underlying async http client
+    # http-client: {
+    #   max-concurrency: 10
+    #   max-pending-connection-acquires: 1000
+    #   connection-acquisition-timeout: 2 minutes
+    #   connection-time-to-live: 1 minute
+    #   use-idle-connection-reaper: false
+    #   read-timeout: 100 seconds
+    #   write-timeout: 100 seconds
+    # }
 }

--- a/aws-auth/src/test/resources/snake_case.conf
+++ b/aws-auth/src/test/resources/snake_case.conf
@@ -1,0 +1,7 @@
+ monix_aws: {
+   credentials {
+      provider: "default"
+   }
+   region: "eu-west-1"
+   endpoint: "snake:12345"
+ }

--- a/aws-auth/src/test/scala/monix/connect/aws/auth/MonixAwsConfigSpec.scala
+++ b/aws-auth/src/test/scala/monix/connect/aws/auth/MonixAwsConfigSpec.scala
@@ -21,23 +21,23 @@ import java.net.URI
 import org.scalatest.flatspec.AnyFlatSpec
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
-import MonixAwsConf._
 import monix.connect.aws.auth.MonixAwsConf.AppConf
 import org.scalatest.matchers.should.Matchers
 import pureconfig.error.ConfigReaderException
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.Region
-
+import monix.connect.aws.auth.MonixAwsConf._
 import scala.util.Try
 
 class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
 
   "MonixAwsConf" should "load from default config file" in {
     //given/when
-    val monixAwsConf = MonixAwsConf.loadOrThrow
+    import monix.execution.Scheduler.Implicits.global
+    val monixAwsConf = MonixAwsConf.load.runSyncUnsafe()
 
     //then
-    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
     monixAwsConf.endpoint.isDefined shouldBe false
     monixAwsConf.region shouldBe Region.EU_WEST_1
   }
@@ -62,7 +62,7 @@ class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
     val monixAwsConf = configSource.loadOrThrow[AppConf].monixAws
 
     //then
-    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
     monixAwsConf.endpoint shouldBe Some(URI.create("localhost:4566"))
     monixAwsConf.httpClient.isDefined shouldBe false
     monixAwsConf.region shouldBe Region.AWS_GLOBAL
@@ -87,7 +87,7 @@ class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
     val monixAwsConf = configSource.loadOrThrow[AppConf].monixAws
 
     //then
-    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
     monixAwsConf.endpoint.isDefined shouldBe false
     monixAwsConf.httpClient.isDefined shouldBe false
     monixAwsConf.region shouldBe Region.AWS_GLOBAL

--- a/aws-auth/src/test/scala/monix/connect/aws/auth/MonixAwsConfigSpec.scala
+++ b/aws-auth/src/test/scala/monix/connect/aws/auth/MonixAwsConfigSpec.scala
@@ -19,27 +19,57 @@ package monix.connect.aws.auth
 
 import java.net.URI
 import org.scalatest.flatspec.AnyFlatSpec
-import pureconfig.ConfigSource
+import pureconfig.{CamelCase, ConfigFieldMapping, ConfigSource, KebabCase, PascalCase, SnakeCase}
 import pureconfig.generic.auto._
-import monix.connect.aws.auth.MonixAwsConf.AppConf
 import org.scalatest.matchers.should.Matchers
 import pureconfig.error.ConfigReaderException
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import monix.connect.aws.auth.MonixAwsConf._
+import monix.execution.Scheduler.Implicits.global
+import pureconfig.generic.ProductHint
+
+import java.io.File
 import scala.util.Try
 
 class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
 
   "MonixAwsConf" should "load from default config file" in {
     //given/when
-    import monix.execution.Scheduler.Implicits.global
-    val monixAwsConf = MonixAwsConf.load.runSyncUnsafe()
+    val monixAwsConf = MonixAwsConf.load().runSyncUnsafe()
 
     //then
-    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
-    monixAwsConf.endpoint.isDefined shouldBe false
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint.isDefined shouldBe true
     monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it should "read the local endpoint as a uri" in {
+
+    //given
+    implicit val hint: ProductHint[AppConf] =
+      ProductHint(ConfigFieldMapping(CamelCase, KebabCase), useDefaultArgs = false, allowUnknownKeys = true)
+
+    val configSource = ConfigSource.string(
+      "" +
+        s"""
+           |monix-aws: {
+           |  credentials: {
+           |           provider: "default"
+           |   }
+           |    region: "aws-global"
+           |    endpoint: "localhost:4566"
+           |}
+           |""".stripMargin)
+
+    //when
+    val monixAwsConf = configSource.loadOrThrow[AppConf].monixAws
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("localhost:4566"))
+    monixAwsConf.httpClient.isDefined shouldBe false
+    monixAwsConf.region shouldBe Region.AWS_GLOBAL
   }
 
   it should "not require endpoint nor http client settings" in {
@@ -53,7 +83,6 @@ class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
            |      provider: "default"
            |    }
            |    region: "aws-global"
-           |    endpoint: "localhost:4566"
            |  }
            |}
            |""".stripMargin)
@@ -62,32 +91,7 @@ class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
     val monixAwsConf = configSource.loadOrThrow[AppConf].monixAws
 
     //then
-    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
-    monixAwsConf.endpoint shouldBe Some(URI.create("localhost:4566"))
-    monixAwsConf.httpClient.isDefined shouldBe false
-    monixAwsConf.region shouldBe Region.AWS_GLOBAL
-  }
-
-  it should "read the local endpoint as a uri" in {
-    //given
-    val configSource = ConfigSource.string(
-      "" +
-        s"""
-           |{
-           |  monix-aws: {
-           |    credentials: {
-           |      provider: "default"
-           |    }
-           |    region: "aws-global"
-           |  }
-           |}
-           |""".stripMargin)
-
-    //when
-    val monixAwsConf = configSource.loadOrThrow[AppConf].monixAws
-
-    //then
-    monixAwsConf.credentialsProvider shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
     monixAwsConf.endpoint.isDefined shouldBe false
     monixAwsConf.httpClient.isDefined shouldBe false
     monixAwsConf.region shouldBe Region.AWS_GLOBAL
@@ -135,6 +139,70 @@ class MonixAwsConfigSpec extends AnyFlatSpec with Matchers {
     monixAwsConf.isFailure shouldBe true
     monixAwsConf.failed.get shouldBe a[ConfigReaderException[_]]
     monixAwsConf.failed.get.getMessage should include("Key not found: 'region'")
+  }
+
+  it can "read config in kebabCase" in {
+    //given/when
+    val monixAwsConf =
+      MonixAwsConf.file(new File("aws-auth/src/test/resources/kebab-case.conf"), KebabCase).runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("kebab-case:12345"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it can "read config in snake_case" in {
+    //given/when
+    val monixAwsConf =
+      MonixAwsConf.file(new File("aws-auth/src/test/resources/snake_case.conf"), SnakeCase).runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("snake:12345"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it can "read config in PascalCase" in {
+    //given/when
+    val monixAwsConf =
+      MonixAwsConf.file(new File("aws-auth/src/test/resources/PascalCase.conf"), PascalCase).runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("PascalCase:12345"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it can "read config in camelCase" in {
+    //given/when
+    val monixAwsConf =
+      MonixAwsConf.file(new File("aws-auth/src/test/resources/camelCase.conf"), CamelCase).runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("camelCase:12345"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it should "read config in kebab-case by default from reference.conf " in {
+    //given/when
+    val monixAwsConf = MonixAwsConf.load().runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("localhost:4566"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
+  }
+
+  it should "read config in camelCase by default when reading from path" in {
+    //given/when
+    val monixAwsConf = MonixAwsConf.file(new File("aws-auth/src/test/resources/kebab-case.conf")).runSyncUnsafe()
+
+    //then
+    monixAwsConf.credentials shouldBe a[DefaultCredentialsProvider]
+    monixAwsConf.endpoint shouldBe Some(URI.create("kebab-case:12345"))
+    monixAwsConf.region shouldBe Region.EU_WEST_1
   }
 
 }

--- a/aws-auth/src/test/scala/monix/connect/aws/auth/ProviderSpec.scala
+++ b/aws-auth/src/test/scala/monix/connect/aws/auth/ProviderSpec.scala
@@ -22,25 +22,25 @@ import org.scalatest.matchers.should.Matchers
 
 class ProviderSpec extends AnyFlatSpec with Matchers {
 
-  s"$Provider" should "be parsed from anonymous,chain, default, environment, instance, profile, static and system" in {
-    Provider.fromString("anonymous") shouldBe Provider.Anonymous
-    Provider.fromString("default") shouldBe Provider.Default
-    Provider.fromString("environment") shouldBe Provider.Environment
-    Provider.fromString("instance") shouldBe Provider.Instance
-    Provider.fromString("profile") shouldBe Provider.Profile
-    Provider.fromString("static") shouldBe Provider.Static
-    Provider.fromString("system") shouldBe Provider.System
-    Provider.fromString("malformed") shouldBe Provider.Default
+  s"$Providers" should "be parsed from anonymous,chain, default, environment, instance, profile, static and system" in {
+    Providers.fromString("anonymous") shouldBe Providers.Anonymous
+    Providers.fromString("default") shouldBe Providers.Default
+    Providers.fromString("environment") shouldBe Providers.Environment
+    Providers.fromString("instance") shouldBe Providers.Instance
+    Providers.fromString("profile") shouldBe Providers.Profile
+    Providers.fromString("static") shouldBe Providers.Static
+    Providers.fromString("system") shouldBe Providers.System
+    Providers.fromString("malformed") shouldBe Providers.Default
   }
 
   it should "not be case sensitive" in {
-    Provider.fromString("Anonymous") shouldBe Provider.Anonymous
-    Provider.fromString("DEFAULT") shouldBe Provider.Default
-    Provider.fromString("ENVironment") shouldBe Provider.Environment
-    Provider.fromString("instancE") shouldBe Provider.Instance
-    Provider.fromString("Profile") shouldBe Provider.Profile
-    Provider.fromString("StatiC") shouldBe Provider.Static
-    Provider.fromString("SYStem") shouldBe Provider.System
+    Providers.fromString("Anonymous") shouldBe Providers.Anonymous
+    Providers.fromString("DEFAULT") shouldBe Providers.Default
+    Providers.fromString("ENVironment") shouldBe Providers.Environment
+    Providers.fromString("instancE") shouldBe Providers.Instance
+    Providers.fromString("Profile") shouldBe Providers.Profile
+    Providers.fromString("StatiC") shouldBe Providers.Static
+    Providers.fromString("SYStem") shouldBe Providers.System
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ skip in publish := true //requered by sbt-ci-release
 lazy val sharedSettings = Seq(
   scalaVersion       := "2.13.5",
   crossScalaVersions := Seq("2.12.14", "2.13.5"),
-  scalafmtOnCompile  := true,
+  scalafmtOnCompile  := false,
   scalacOptions ++= Seq(
     // warnings
     "-unchecked", // able additional warnings where generated code depends on assumptions

--- a/docs/dynamo.md
+++ b/docs/dynamo.md
@@ -44,7 +44,6 @@ libraryDependencies += "io.monix" %% "monix-dynamodb" % "0.6.0"
   _http client_ settings are commented out since they are optional, however they could have been specified too for a more fine grained configuration of the underlying `NettyNioAsyncHttpClient`.
     
 ```hocon
-{
   monix-aws: {
     credentials {
       // [anonymous, default, environment, instance, system, profile, static]
@@ -75,7 +74,6 @@ libraryDependencies += "io.monix" %% "monix-dynamodb" % "0.6.0"
     #   write-timeout: 100 seconds
     # }
   }
-}
 ```
 
 This config file should be placed in the `resources` folder, therefore it will be automatically picked up from the method call `S3.fromConfig`, which will return a `cats.effect.Resource[Task, S3]`.
@@ -90,7 +88,6 @@ import monix.connect.dynamodb.DynamoDbOp.Implicits._
 import software.amazon.awssdk.services.dynamodb.model._
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import monix.eval.Task
-import pureconfig.KebabCase
 
 def runDynamoDbApp(dynamoDb: DynamoDb): Task[Array[Byte]] = {
   val tableName = "my-table"
@@ -103,11 +100,11 @@ def runDynamoDbApp(dynamoDb: DynamoDb): Task[Array[Byte]] = {
 }
 
 // It allows to specify the [[pureconfig.NamingConvention]] 
-// from its argument, by default it uses the [[KebabCase]].
+// from its argument, by default it uses the [[pureconfig.KebabCase]].
 val f = DynamoDb.fromConfig(KebabCase).use(runDynamoDbApp).runToFuture
 // the connection gets created and released within the use method and the `DynamoDb`
 // instance is directly passed to our application for an easier interoperability
-```  
+```
 
 There is an alternative way to use `fromConfig` which is to load the config first and then passing it to
 the method. The difference is that in this case we will be able to override a specific configuration

--- a/docs/dynamo.md
+++ b/docs/dynamo.md
@@ -85,12 +85,12 @@ We recommend using it transparently in your application, meaning that your metho
 _usage_ of the _Resource_. See below code snippet to understand the concept:
 
 ```scala
- 
 import monix.connect.dynamodb.DynamoDb
 import monix.connect.dynamodb.DynamoDbOp.Implicits._
 import software.amazon.awssdk.services.dynamodb.model._
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import monix.eval.Task
+import pureconfig.KebabCase
 
 def runDynamoDbApp(dynamoDb: DynamoDb): Task[Array[Byte]] = {
   val tableName = "my-table"
@@ -102,16 +102,35 @@ def runDynamoDbApp(dynamoDb: DynamoDb): Task[Array[Byte]] = {
   } yield ()
 }
 
+// It allows to specify the [[pureconfig.NamingConvention]] 
+// from its argument, by default it uses the [[KebabCase]].
+val f = DynamoDb.fromConfig(KebabCase).use(runDynamoDbApp).runToFuture
 // the connection gets created and released within the use method and the `DynamoDb`
 // instance is directly passed to our application for an easier interoperability
-val f = DynamoDb.fromConfig.use(runDynamoDbApp(_)).runToFuture
 ```  
-    
- ### Create
- 
- An alternative to using a config file is to pass the _AWS configurations_ by parameters.
- This is a safe implementation since the method, again, handles the _creation_ and _release_ of the connection with the _cats effect_ 
- `Resource` data type. The example below produce exactly the same result as previously using the _config_ file:
+
+There is an alternative way to use `fromConfig` which is to load the config first and then passing it to
+the method. The difference is that in this case we will be able to override a specific configuration
+from the code, whereas before we were reading it and creating the client straight after.
+
+```scala
+ import monix.connect.aws.auth.MonixAwsConf
+ import monix.connect.dynamodb.DynamoDb
+ import monix.eval.Task
+ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+ import pureconfig.KebabCase
+ import software.amazon.awssdk.regions.Region
+
+ val f = MonixAwsConf.load(KebabCase).memoizeOnSuccess.flatMap{ awsConf =>
+   val updatedAwsConf = awsConf.copy(region = Region.EU_CENTRAL_1)
+   DynamoDb.fromConfig(updatedAwsConf).use(runDynamoDbApp)
+ }.runToFuture
+```
+
+## Create
+
+On the other hand, one can pass the _AWS configurations_ by parameters, and that is safe since the method also handles the _acquisition_ and _release_ of the connection with
+`Resource`. The example below produce exactly the same result as previously using the _config_ file:
  
  ```scala
  import cats.effect.Resource

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -36,7 +36,6 @@ This module exposes a wide range of methods for interacting with S3 _buckets_ an
   _http client_ settings are commented out since they are optional, however they could have been specified too for a more fine grained configuration of the underlying `NettyNioAsyncHttpClient`.
     
 ```hocon
-{
   monix-aws: {
     credentials {
       // [anonymous, default, environment, instance, system, profile, static]
@@ -67,7 +66,6 @@ This module exposes a wide range of methods for interacting with S3 _buckets_ an
     #   write-timeout: 100 seconds
     # }
   }
-}
 ```
 
 This config file should be placed in the `resources` folder, therefore it will be automatically picked up from the method call `S3.fromConfig`, which will return a `cats.effect.Resource[Task, S3]`.

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -81,6 +81,7 @@ multiple times will waste precious resources... See below code snippet to unders
  import monix.connect.s3.S3
  import monix.eval.Task
  import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+ import pureconfig.KebabCase
 
  val bucket = "my-bucket"
  val key = "my-key"
@@ -98,15 +99,35 @@ multiple times will waste precious resources... See below code snippet to unders
    } yield download
  }
 
-  // the connection gets created and released within the use method and the `S3`
+
+  // It allows to specify the [[pureconfig.NamingConvention]]
+  // from its argument, by default it uses the [[KebabCase]].  
+  val f = S3.fromConfig(KebabCase).use(s3 => runS3App(s3)).runToFuture
+  // The connection got created and released within the use method and the `S3`
   // instance is directly passed and should be reused across our application
-  val f = S3.fromConfig.use(s3 => runS3App(s3)).runToFuture
 ```  
-    
+
+There is an alternative way to use `fromConfig` which is to load the config first and then passing it to
+the method. The difference is that in this case we will be able to override a specific configuration 
+from the code, whereas before we were reading it and creating the client straight after.
+
+```scala
+ import monix.connect.aws.auth.MonixAwsConf
+ import monix.connect.s3.S3
+ import monix.eval.Task
+ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+ import pureconfig.KebabCase
+ import software.amazon.awssdk.regions.Region
+
+ val f = MonixAwsConf.load(KebabCase).memoizeOnSuccess.flatMap{ awsConf =>
+   val updatedAwsConf = awsConf.copy(region = Region.EU_CENTRAL_1)
+   S3.fromConfig(updatedAwsConf).use(s3 => runS3App(s3))
+ }.runToFuture
+```
+
 ## Create
  
- An alternative to using a config file is to pass the _AWS configurations_ by parameters.
- This is a safe implementation since the method also handles the _acquisition_ and _release_ of the connection with
+ On the other hand, one can pass the _AWS configurations_ by parameters, and that is safe since the method also handles the _acquisition_ and _release_ of the connection with
  `Resource`. The example below produce exactly the same result as previously using the _config_ file:
  
  ```scala

--- a/docs/sqs.md
+++ b/docs/sqs.md
@@ -83,6 +83,8 @@ multiple times will waste precious resources... See below code snippet to unders
  import monix.eval.Task
  import scalapb.descriptors.ScalaType.Message
  import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+ import pureconfig.KebabCase
+
  import scala.concurrent.duration._
  
  def runSqsApp(sqs: Sqs): Task[Array[Byte]] = {
@@ -94,16 +96,35 @@ multiple times will waste precious resources... See below code snippet to unders
      receivedMessage <- sqs.consumer.receiveSingleManualDelete(queueUrl, waitTimeSeconds = 3.seconds)
    } yield receivedMessage
  }
- 
-  // the connection gets created and released within the use method and the `Sqs`
+
+  // It allows to specify the [[pureconfig.NamingConvention]]
+  // from its argument, by default it uses the [[KebabCase]].  
+  val f = Sqs.fromConfig(KebabCase).use(runSqsApp).runToFuture
+  // The connection gets created and released within the use method and the `Sqs`
   // instance is directly passed and should be reused across our application
-  val f = Sqs.fromConfig.use(runSqsApp).runToFuture
 ```  
 
-### Create
+There is an alternative way to use `fromConfig` which is to load the config first and then passing it to
+the method. The difference is that in this case we will be able to override a specific configuration
+from the code, whereas before we were reading it and creating the client straight after.
 
-An alternative to using a config file is to pass the _AWS configurations_ directly by parameters.
-This is a safe implementation since the method also handles the _acquisition_ and _release_ of the connection within
+```scala
+ import monix.connect.aws.auth.MonixAwsConf
+ import monix.connect.sqs.Sqs
+ import monix.eval.Task
+ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+ import pureconfig.KebabCase
+ import software.amazon.awssdk.regions.Region
+
+ val f = MonixAwsConf.load(KebabCase).memoizeOnSuccess.flatMap{ awsConf =>
+   val updatedAwsConf = awsConf.copy(region = Region.EU_CENTRAL_1)
+   Sqs.fromConfig(updatedAwsConf).use(runSqsApp)
+ }.runToFuture
+```
+
+## Create
+
+On the other hand, one can pass the _AWS configurations_ by parameters, and that is safe since the method also handles the _acquisition_ and _release_ of the connection with
 `Resource`. The example below produce exactly the same result as previously using the _config_ file:
 
  ```scala

--- a/docs/sqs.md
+++ b/docs/sqs.md
@@ -36,7 +36,6 @@ Below snippet shows an example of the configuration file to authenticate via `St
 _http client_ settings are commented out since they are optional, however they could have been specified too for a more fine-grained configuration of the underlying `NettyNioAsyncHttpClient`.
 
 ```hocon
-{
   monix-aws: {
     credentials {
       // [anonymous, default, environment, instance, system, profile, static]
@@ -67,7 +66,6 @@ _http client_ settings are commented out since they are optional, however they c
     #   write-timeout: 100 seconds
     # }
   }
-}
 ```
 
 This config file should be placed in the `resources` folder, therefore it will be automatically picked up from the method call `Sqs.fromConfig`, which will return a `cats.effect.Resource[Task, Sqs]`.

--- a/dynamodb/src/it/scala/monix/connect/dynamodb/DynamoDbSuite.scala
+++ b/dynamodb/src/it/scala/monix/connect/dynamodb/DynamoDbSuite.scala
@@ -39,7 +39,7 @@ class DynamoDbSuite extends AnyFlatSpec with Matchers with DynamoDbFixture with 
     val listRequest = ListTablesRequest.builder.build
 
     //when
-    val listTables: ListTablesResponse = MonixAwsConf.load.memoizeOnSuccess.flatMap(DynamoDb.fromConfig(_).use(_.single(listRequest))).runSyncUnsafe()
+    val listTables: ListTablesResponse = MonixAwsConf.load().memoizeOnSuccess.flatMap(DynamoDb.fromConfig(_).use(_.single(listRequest))).runSyncUnsafe()
 
     //then
     listTables shouldBe a[ListTablesResponse]
@@ -52,7 +52,7 @@ class DynamoDbSuite extends AnyFlatSpec with Matchers with DynamoDbFixture with 
     val listRequest = ListTablesRequest.builder.build
 
     //when
-    val monixAwsConf = MonixAwsConf.load.memoizeOnSuccess
+    val monixAwsConf = MonixAwsConf.load().memoizeOnSuccess
     val listTables: ListTablesResponse = DynamoDb.fromConfig(monixAwsConf).use(_.single(listRequest)).runSyncUnsafe()
 
     //then

--- a/dynamodb/src/main/scala/monix/connect/dynamodb/AsyncClientConversions.scala
+++ b/dynamodb/src/main/scala/monix/connect/dynamodb/AsyncClientConversions.scala
@@ -33,7 +33,7 @@ private[dynamodb] object AsyncClientConversions { self =>
 
   def fromMonixAwsConf(monixAwsConf: MonixAwsConf): DynamoDbAsyncClient = {
     val builder =
-      DynamoDbAsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
+      DynamoDbAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride(_))
     builder.build()

--- a/dynamodb/src/main/scala/monix/connect/dynamodb/AsyncClientConversions.scala
+++ b/dynamodb/src/main/scala/monix/connect/dynamodb/AsyncClientConversions.scala
@@ -33,7 +33,7 @@ private[dynamodb] object AsyncClientConversions { self =>
 
   def fromMonixAwsConf(monixAwsConf: MonixAwsConf): DynamoDbAsyncClient = {
     val builder =
-      DynamoDbAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
+      DynamoDbAsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride(_))
     builder.build()

--- a/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
+++ b/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
@@ -55,6 +55,7 @@ object DynamoDb { self =>
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.dynamodb.DynamoDb
+    *   import monix.eval.Task
     *
     *   DynamoDb.fromConfig.use { dynamoDb =>
     *      //business logic here
@@ -90,6 +91,7 @@ object DynamoDb { self =>
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.dynamodb.DynamoDb
+    *   import monix.eval.Task
     *
     *   DynamoDb.fromConfig.use { dynamoDb =>
     *      //business logic here
@@ -122,6 +124,7 @@ object DynamoDb { self =>
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.dynamodb.DynamoDb
+    *   import monix.eval.Task
     *   import software.amazon.awssdk.regions.Region
 
     *   MonixAwsConf.load().flatMap{ awsConf =>

--- a/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
+++ b/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
@@ -160,7 +160,7 @@ object DynamoDb { self =>
     *   import monix.eval.Task
     *   import monix.connect.dynamodb.DynamoDb
     *
-    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   val awsConf: Task[MonixAwsConf] = MonixAwsConf.load()
     *   DynamoDb.fromConfig(awsConf).use { dynamoDb =>
     *          //business logic here
     *          Task.unit

--- a/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
+++ b/dynamodb/src/main/scala/monix/connect/dynamodb/DynamoDb.scala
@@ -24,6 +24,7 @@ import monix.connect.dynamodb.domain.DefaultRetryStrategy
 import monix.eval.Task
 import monix.execution.annotations.UnsafeBecauseImpure
 import monix.reactive.{Consumer, Observable}
+import pureconfig.{KebabCase, NamingConvention}
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.regions.Region
@@ -41,27 +42,142 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 object DynamoDb { self =>
 
   /**
-    * Creates a [[Resource]] that will use the values from a
-    * configuration file to allocate and release a [[DynamoDb]].
-    * Thus, the api expects an `application.conf` file to be present
-    * in the `resources` folder.
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[DynamoDb]] instance.
     *
-    * @see how does the expected `.conf` file should look like
-    *      https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
     *
-    * @see the cats effect resource data type: https://typelevel.org/cats-effect/datatypes/resource.html
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.dynamodb.DynamoDb
+    *
+    *   DynamoDb.fromConfig.use { dynamoDb =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
     *
     * @return a [[Resource]] of [[Task]] that allocates and releases a Monix [[DynamoDb]] client.
     */
+  @deprecated("Use `fromConfig(namingConvention)`", "0.6.1")
   def fromConfig: Resource[Task, DynamoDb] = {
     Resource.make {
       for {
-        monixAwsConf <- Task.from(MonixAwsConf.load)
+        monixAwsConf <- Task.from(MonixAwsConf.load())
         asyncClient  <- Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
       } yield {
         self.createUnsafe(asyncClient)
       }
     } { _.close }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[DynamoDb]] instance.
+    *
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.dynamodb.DynamoDb
+    *
+    *   DynamoDb.fromConfig.use { dynamoDb =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
+    *
+    * @return a [[Resource]] of [[Task]] that allocates and releases a Monix [[DynamoDb]] client.
+    */
+  def fromConfig(namingConvention: NamingConvention = KebabCase): Resource[Task, DynamoDb] = {
+    Resource.make {
+      for {
+        monixAwsConf <- Task.from(MonixAwsConf.load(namingConvention))
+        asyncClient  <- Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
+      } yield {
+        self.createUnsafe(asyncClient)
+      }
+    } { _.close }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[DynamoDb]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.dynamodb.DynamoDb
+    *   import software.amazon.awssdk.regions.Region
+
+    *   MonixAwsConf.load().flatMap{ awsConf =>
+    *       // you can update your config from code too
+    *       val updatedAwsConf = awsConf.copy(region = Region.AP_SOUTH_1)
+    *       DynamoDb.fromConfig(updatedAwsConf).use { dynamoDb =>
+    *          //business logic here
+    *          Task.unit
+    *       }
+    *   }
+    * }}}
+    *
+    * @param monixAwsConf the monix aws config read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[DynamoDb]].
+    */
+  def fromConfig(monixAwsConf: MonixAwsConf): Resource[Task, DynamoDb] = {
+    Resource.make {
+      Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf)).map(this.createUnsafe)
+    } {
+      _.close
+    }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[DynamoDb]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.eval.Task
+    *   import monix.connect.dynamodb.DynamoDb
+    *
+    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   DynamoDb.fromConfig(awsConf).use { dynamoDb =>
+    *          //business logic here
+    *          Task.unit
+    *    }
+    * }}}
+    *
+    * @param monixAwsConf a task containing the monix aws config
+    *                     read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[DynamoDb]].
+    */
+  def fromConfig(monixAwsConf: Task[MonixAwsConf]): Resource[Task, DynamoDb] = {
+    Resource.make {
+      monixAwsConf.map(AsyncClientConversions.fromMonixAwsConf).map(this.createUnsafe)
+    } {
+      _.close
+    }
   }
 
   /**

--- a/s3/src/it/resources/application.conf
+++ b/s3/src/it/resources/application.conf
@@ -1,6 +1,4 @@
-{
-
-  monix-aws: {
+monix-aws: {
 
     credentials {
 
@@ -49,7 +47,5 @@
     #   read-timeout: 100 seconds
     #   write-timeout: 100 seconds
     # }
-
-  }
 
 }

--- a/s3/src/it/scala/monix/connect/s3/S3Suite.scala
+++ b/s3/src/it/scala/monix/connect/s3/S3Suite.scala
@@ -422,7 +422,7 @@ class S3Suite
     S3.fromConfig.use { s3 =>
       for {
         //when
-        _ <- Task.traverse(keys) { key => S3.fromConfig.use(_.upload(bucketName, key, "dummyContent".getBytes())) }
+        _ <- Task.traverse(keys) { key => s3.upload(bucketName, key, "dummyContent".getBytes()) }
         latest <- s3.listLatestObject(bucketName, prefix = Some(prefix))
         latestFive <- s3.listLatestNObjects(bucketName, 5, prefix = Some(prefix)).toListL
         all <- s3.listObjects(bucketName, prefix = Some(prefix)).toListL
@@ -447,7 +447,7 @@ class S3Suite
     S3.fromConfig.use { s3 =>
       for {
         _ <- Task
-          .traverse(keys) { key => S3.fromConfig.use(_.upload(bucketName, key, "dummyContent".getBytes())) }
+          .traverse(keys) { key => s3.upload(bucketName, key, "dummyContent".getBytes()) }
         oldest <- s3.listOldestObject(bucketName, prefix = Some(prefix))
         oldestFive <- s3.listOldestNObjects(bucketName, 5, prefix = Some(prefix)).toListL
         all <- s3.listObjects(bucketName, prefix = Some(prefix)).toListL
@@ -471,7 +471,7 @@ class S3Suite
     S3.fromConfig.use { s3 =>
       for {
         _ <- Task
-          .traverse(keys) { key => S3.fromConfig.use(_.upload(bucketName, key, "dummyContent".getBytes())) }
+          .traverse(keys) { key => s3.upload(bucketName, key, "dummyContent".getBytes()) }
         all <- s3.listObjects(bucketName, prefix = Some(prefix)).toListL
         listNObjects <- s3.listOldestNObjects(bucketName, all.size + 10, prefix = Some(prefix)).toListL
       } yield {

--- a/s3/src/it/scala/monix/connect/s3/S3Suite.scala
+++ b/s3/src/it/scala/monix/connect/s3/S3Suite.scala
@@ -50,7 +50,7 @@ class S3Suite
 
   it can "be created from a raw monix aws conf" in {
     //given
-    val monixAwsConf = MonixAwsConf.load
+    val monixAwsConf = MonixAwsConf.load()
     val s3FromConf = monixAwsConf.map(S3.fromConfig).memoizeOnSuccess
     val (k1, k2) = (Gen.identifier.sample.get, Gen.identifier.sample.get)
 
@@ -74,7 +74,7 @@ class S3Suite
 
   it can "be created from task monix aws conf" in {
     //given
-    val monixAwsConf = MonixAwsConf.load.memoizeOnSuccess
+    val monixAwsConf = MonixAwsConf.load().memoizeOnSuccess
     val s3FromConf =S3.fromConfig(monixAwsConf)
     val (k1, k2) = (Gen.identifier.sample.get, Gen.identifier.sample.get)
 

--- a/s3/src/it/scala/monix/connect/s3/S3Suite.scala
+++ b/s3/src/it/scala/monix/connect/s3/S3Suite.scala
@@ -1,14 +1,15 @@
 package monix.connect.s3
 
-import java.io.FileInputStream
+import monix.connect.aws.auth.MonixAwsConf
 
+import java.io.FileInputStream
 import monix.eval.Task
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterAll
 import software.amazon.awssdk.services.s3.model.{CompleteMultipartUploadResponse, CopyObjectResponse, NoSuchBucketException, NoSuchKeyException, PutObjectResponse}
 import org.scalatest.matchers.should.Matchers
-import Thread.sleep
 
+import Thread.sleep
 import scala.concurrent.duration._
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.{Consumer, Observable}
@@ -32,7 +33,7 @@ class S3Suite
     }
   }
 
-  s"${S3}" can "be created from config files" in {
+  "S3" can "be created from config file" in {
     //given
     val s3FromConf = S3.fromConfig
     val (k1, k2) = (Gen.identifier.sample.get, Gen.identifier.sample.get)
@@ -45,6 +46,51 @@ class S3Suite
     val (exists1, exists2) = s3FromConf.use(s3 => Task.parZip2(s3.existsObject(bucketName, k1), s3.existsObject(bucketName, k2))).runSyncUnsafe()
     exists1 shouldBe true
     exists2 shouldBe true
+  }
+
+  it can "be created from a raw monix aws conf" in {
+    //given
+    val monixAwsConf = MonixAwsConf.load
+    val s3FromConf = monixAwsConf.map(S3.fromConfig).memoizeOnSuccess
+    val (k1, k2) = (Gen.identifier.sample.get, Gen.identifier.sample.get)
+
+    //when
+    s3FromConf.map(resource =>
+      resource.use { s3 =>
+        for {
+          _ <- s3.upload(bucketName, k1, k1.getBytes()) >>
+            s3.upload(bucketName, k2, k2.getBytes())
+          existsKey1 <- s3.existsObject(bucketName, k1)
+          existsKey2 <- s3.existsObject(bucketName, k2)
+        } yield {
+          //then
+          existsKey1 shouldBe true
+          existsKey2 shouldBe true
+        }
+      }
+    ).runSyncUnsafe()
+
+  }
+
+  it can "be created from task monix aws conf" in {
+    //given
+    val monixAwsConf = MonixAwsConf.load.memoizeOnSuccess
+    val s3FromConf =S3.fromConfig(monixAwsConf)
+    val (k1, k2) = (Gen.identifier.sample.get, Gen.identifier.sample.get)
+
+    //when
+    s3FromConf.use { s3 =>
+      for {
+        _ <- s3.upload(bucketName, k1, k1.getBytes()) >>
+          s3.upload(bucketName, k2, k2.getBytes())
+        existsKey1 <- s3.existsObject(bucketName, k1)
+        existsKey2 <- s3.existsObject(bucketName, k2)
+      } yield {
+        //then
+        existsKey1 shouldBe true
+        existsKey2 shouldBe true
+      }
+    }.runSyncUnsafe()
   }
 
   it should "implement upload method" in {

--- a/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
+++ b/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
@@ -32,7 +32,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient
 private[s3] object AsyncClientConversions { self =>
 
   private[s3] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): S3AsyncClient = {
-    val builder = S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
+    val builder =
+      S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
+++ b/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
@@ -33,7 +33,7 @@ private[s3] object AsyncClientConversions { self =>
 
   private[s3] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): S3AsyncClient = {
     val builder =
-      S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
+      S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
+++ b/s3/src/main/scala/monix/connect/s3/AsyncClientConversions.scala
@@ -32,7 +32,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient
 private[s3] object AsyncClientConversions { self =>
 
   private[s3] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): S3AsyncClient = {
-    val builder = S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
+    val builder = S3AsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/s3/src/main/scala/monix/connect/s3/S3.scala
+++ b/s3/src/main/scala/monix/connect/s3/S3.scala
@@ -214,7 +214,7 @@ object S3 {
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.eval.Task
     *   import monix.connect.s3.S3
-    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   val awsConf: Task[MonixAwsConf] = MonixAwsConf.load()
     *   Sqs.fromConfig(awsConf).use { s3 =>
     *          //business logic here
     *          Task.unit

--- a/s3/src/main/scala/monix/connect/s3/S3.scala
+++ b/s3/src/main/scala/monix/connect/s3/S3.scala
@@ -219,7 +219,7 @@ object S3 {
     *   import monix.connect.s3.S3
     *
     *   val awsConf: Task[MonixAwsConf] = MonixAwsConf.load()
-    *   Sqs.fromConfig(awsConf).use { s3 =>
+    *   S3.fromConfig(awsConf).use { s3 =>
     *          //business logic here
     *          Task.unit
     *    }

--- a/s3/src/main/scala/monix/connect/s3/S3.scala
+++ b/s3/src/main/scala/monix/connect/s3/S3.scala
@@ -19,7 +19,15 @@ package monix.connect.s3
 
 import cats.effect.Resource
 import monix.connect.aws.auth.MonixAwsConf
-import monix.connect.s3.domain.{CopyObjectSettings, DefaultCopyObjectSettings, DefaultDownloadSettings, DefaultUploadSettings, DownloadSettings, UploadSettings, awsMinChunkSize}
+import monix.connect.s3.domain.{
+  awsMinChunkSize,
+  CopyObjectSettings,
+  DefaultCopyObjectSettings,
+  DefaultDownloadSettings,
+  DefaultUploadSettings,
+  DownloadSettings,
+  UploadSettings
+}
 import monix.reactive.{Consumer, Observable}
 import monix.eval.Task
 import monix.execution.annotations.{Unsafe, UnsafeBecauseImpure}
@@ -29,7 +37,26 @@ import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransfo
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.model.{Bucket, BucketCannedACL, CompleteMultipartUploadResponse, CopyObjectRequest, CopyObjectResponse, CreateBucketRequest, CreateBucketResponse, DeleteBucketRequest, DeleteBucketResponse, DeleteObjectRequest, DeleteObjectResponse, GetObjectRequest, GetObjectResponse, NoSuchKeyException, PutObjectRequest, PutObjectResponse, RequestPayer, S3Object}
+import software.amazon.awssdk.services.s3.model.{
+  Bucket,
+  BucketCannedACL,
+  CompleteMultipartUploadResponse,
+  CopyObjectRequest,
+  CopyObjectResponse,
+  CreateBucketRequest,
+  CreateBucketResponse,
+  DeleteBucketRequest,
+  DeleteBucketResponse,
+  DeleteObjectRequest,
+  DeleteObjectResponse,
+  GetObjectRequest,
+  GetObjectResponse,
+  NoSuchKeyException,
+  PutObjectRequest,
+  PutObjectResponse,
+  RequestPayer,
+  S3Object
+}
 
 import scala.jdk.CollectionConverters._
 
@@ -168,7 +195,7 @@ object S3 {
     */
   def fromConfig(monixAwsConf: MonixAwsConf): Resource[Task, S3] = {
     Resource.make {
-       Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf)).map(this.createUnsafe)
+      Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf)).map(this.createUnsafe)
     } {
       _.close
     }

--- a/s3/src/main/scala/monix/connect/s3/S3.scala
+++ b/s3/src/main/scala/monix/connect/s3/S3.scala
@@ -106,6 +106,7 @@ object S3 {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.s3.S3
+    *   import monix.eval.Task
     *
     *   S3.fromConfig.use { s3 =>
     *      //business logic here
@@ -143,6 +144,7 @@ object S3 {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.s3.S3
+    *   import monix.eval.Task
     *
     *   S3.fromConfig.use { s3 =>
     *      //business logic here
@@ -177,6 +179,7 @@ object S3 {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.s3.S3
+    *   import monix.eval.Task
     *   import software.amazon.awssdk.regions.Region
     *
     *   MonixAwsConf.load().flatMap{ awsConf =>
@@ -214,6 +217,7 @@ object S3 {
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.eval.Task
     *   import monix.connect.s3.S3
+    *
     *   val awsConf: Task[MonixAwsConf] = MonixAwsConf.load()
     *   Sqs.fromConfig(awsConf).use { s3 =>
     *          //business logic here

--- a/s3/src/main/scala/monix/connect/s3/S3.scala
+++ b/s3/src/main/scala/monix/connect/s3/S3.scala
@@ -19,43 +19,17 @@ package monix.connect.s3
 
 import cats.effect.Resource
 import monix.connect.aws.auth.MonixAwsConf
-import monix.connect.s3.domain.{
-  awsMinChunkSize,
-  CopyObjectSettings,
-  DefaultCopyObjectSettings,
-  DefaultDownloadSettings,
-  DefaultUploadSettings,
-  DownloadSettings,
-  UploadSettings
-}
+import monix.connect.s3.domain.{CopyObjectSettings, DefaultCopyObjectSettings, DefaultDownloadSettings, DefaultUploadSettings, DownloadSettings, UploadSettings, awsMinChunkSize}
 import monix.reactive.{Consumer, Observable}
 import monix.eval.Task
 import monix.execution.annotations.{Unsafe, UnsafeBecauseImpure}
+import pureconfig.{KebabCase, NamingConvention}
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransformer}
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.model.{
-  Bucket,
-  BucketCannedACL,
-  CompleteMultipartUploadResponse,
-  CopyObjectRequest,
-  CopyObjectResponse,
-  CreateBucketRequest,
-  CreateBucketResponse,
-  DeleteBucketRequest,
-  DeleteBucketResponse,
-  DeleteObjectRequest,
-  DeleteObjectResponse,
-  GetObjectRequest,
-  GetObjectResponse,
-  NoSuchKeyException,
-  PutObjectRequest,
-  PutObjectResponse,
-  RequestPayer,
-  S3Object
-}
+import software.amazon.awssdk.services.s3.model.{Bucket, BucketCannedACL, CompleteMultipartUploadResponse, CopyObjectRequest, CopyObjectResponse, CreateBucketRequest, CreateBucketResponse, DeleteBucketRequest, DeleteBucketResponse, DeleteObjectRequest, DeleteObjectResponse, GetObjectRequest, GetObjectResponse, NoSuchKeyException, PutObjectRequest, PutObjectResponse, RequestPayer, S3Object}
 
 import scala.jdk.CollectionConverters._
 
@@ -92,24 +66,142 @@ object S3 {
   self =>
 
   /**
-    * Creates a [[Resource]] that will use the values from a
-    * configuration file to allocate and release a [[S3]].
-    * Thus, the api expects an `application.conf` file to be present
-    * in the `resources` folder.
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[S3]] instance.
     *
-    * @see how does the expected `.conf` file should look like
-    *      https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
     *
-    * @return a [[Resource]] of [[Task]] that allocates and releases [[S3]].
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.s3.S3
+    *
+    *   S3.fromConfig.use { s3 =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[S3]].
     */
+  @deprecated("Use `fromConfig(namingConvention)`", "0.6.1")
   def fromConfig: Resource[Task, S3] = {
     Resource.make {
       for {
-        monixAwsConf <- Task.from(MonixAwsConf.load)
+        monixAwsConf <- Task.from(MonixAwsConf.load())
         asyncClient  <- Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
       } yield {
         self.createUnsafe(asyncClient)
       }
+    } {
+      _.close
+    }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[S3]] instance.
+    *
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.s3.S3
+    *
+    *   S3.fromConfig.use { s3 =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[S3]].
+    */
+  def fromConfig(namingConvention: NamingConvention = KebabCase): Resource[Task, S3] = {
+    Resource.make {
+      for {
+        monixAwsConf <- Task.from(MonixAwsConf.load(namingConvention))
+        asyncClient  <- Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
+      } yield {
+        self.createUnsafe(asyncClient)
+      }
+    } {
+      _.close
+    }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[S3]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.s3.S3
+    *   import software.amazon.awssdk.regions.Region
+    *
+    *   MonixAwsConf.load().flatMap{ awsConf =>
+    *       // you can update your config from code too
+    *       val updatedAwsConf = awsConf.copy(region = Region.AP_SOUTH_1)
+    *       S3.fromConfig(updatedAwsConf).use { s3 =>
+    *          //business logic here
+    *          Task.unit
+    *       }
+    *   }
+    * }}}
+    *
+    * @param monixAwsConf the monix aws config read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[S3]].
+    */
+  def fromConfig(monixAwsConf: MonixAwsConf): Resource[Task, S3] = {
+    Resource.make {
+       Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf)).map(this.createUnsafe)
+    } {
+      _.close
+    }
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[S3]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.eval.Task
+    *   import monix.connect.s3.S3
+    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   Sqs.fromConfig(awsConf).use { s3 =>
+    *          //business logic here
+    *          Task.unit
+    *    }
+    * }}}
+    *
+    * @param monixAwsConf a task containing the monix aws config
+    *                     read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[S3]].
+    */
+  def fromConfig(monixAwsConf: Task[MonixAwsConf]): Resource[Task, S3] = {
+    Resource.make {
+      monixAwsConf.map(AsyncClientConversions.fromMonixAwsConf).map(this.createUnsafe)
     } {
       _.close
     }

--- a/sqs/src/it/scala/monix.connect.sqs/SqsSuite.scala
+++ b/sqs/src/it/scala/monix.connect.sqs/SqsSuite.scala
@@ -1,0 +1,64 @@
+package monix.connect.sqs
+
+import monix.connect.aws.auth.MonixAwsConf
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import pureconfig.KebabCase
+
+class SqsSuite extends AnyFlatSpecLike with Matchers with BeforeAndAfterEach with SqsITFixture {
+
+  s"$Sqs" can "be created from config file" in {
+
+    Sqs.fromConfig.use { sqs =>
+      for {
+        createdQueueUrl <- sqs.operator.createQueue(fifoQueueName)
+        getQueueUrl <- sqs.operator.getQueueUrl(fifoQueueName)
+      } yield {
+        createdQueueUrl shouldEqual getQueueUrl
+      }
+    }.runSyncUnsafe()
+  }
+
+  it can "be created from config file with an specific naming convention" in {
+
+    Sqs.fromConfig(KebabCase).use { sqs =>
+      for {
+        createdQueueUrl <- sqs.operator.createQueue(fifoQueueName)
+        getQueueUrl <- sqs.operator.getQueueUrl(fifoQueueName)
+      } yield {
+        createdQueueUrl shouldEqual getQueueUrl
+      }
+    }.runSyncUnsafe()
+  }
+
+  it can "be created from monix aws conf" in {
+
+    MonixAwsConf.load().memoizeOnSuccess.flatMap {
+      Sqs.fromConfig(_).use { sqs =>
+        for {
+          createdQueueUrl <- sqs.operator.createQueue(fifoQueueName)
+          getQueueUrl <- sqs.operator.getQueueUrl(fifoQueueName)
+        } yield {
+          createdQueueUrl shouldEqual getQueueUrl
+        }
+      }
+    }.runSyncUnsafe()
+  }
+
+  it can "be created from monix aws conf task" in {
+
+    val monixAwsConf = MonixAwsConf.load()
+    Sqs.fromConfig(monixAwsConf).use { sqs =>
+      for {
+        createdQueueUrl <- sqs.operator.createQueue(fifoQueueName)
+        getQueueUrl <- sqs.operator.getQueueUrl(fifoQueueName)
+      } yield {
+        createdQueueUrl shouldEqual getQueueUrl
+      }
+    }.runSyncUnsafe()
+
+  }
+
+}

--- a/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
@@ -33,7 +33,8 @@ private[sqs] object AsyncClientConversions {
   self =>
 
   private[sqs] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): SqsAsyncClient = {
-    val builder = SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
+    val builder =
+      SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
@@ -33,7 +33,7 @@ private[sqs] object AsyncClientConversions {
   self =>
 
   private[sqs] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): SqsAsyncClient = {
-    val builder = SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
+    val builder = SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/AsyncClientConversions.scala
@@ -34,7 +34,7 @@ private[sqs] object AsyncClientConversions {
 
   private[sqs] def fromMonixAwsConf(monixAwsConf: MonixAwsConf): SqsAsyncClient = {
     val builder =
-      SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentialsProvider).region(monixAwsConf.region)
+      SqsAsyncClient.builder().credentialsProvider(monixAwsConf.credentials).region(monixAwsConf.region)
     monixAwsConf.httpClient.map(httpConf => builder.httpClient(self.httpConfToClient(httpConf)))
     monixAwsConf.endpoint.map(builder.endpointOverride)
     builder.build()

--- a/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
@@ -128,7 +128,7 @@ object Sqs {
     */
   def fromConfig(monixAwsConf: MonixAwsConf): Resource[Task, Sqs] = {
     Resource.make {
-     Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
+      Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
     }(asyncClient => Task.evalAsync(asyncClient.close()))
       .map(this.createUnsafe(_))
   }

--- a/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
@@ -24,6 +24,7 @@ import monix.connect.aws.auth.MonixAwsConf
 import monix.connect.sqs.producer.SqsProducer
 import monix.connect.sqs.consumer.SqsConsumer
 import monix.execution.annotations.UnsafeBecauseImpure
+import pureconfig.{KebabCase, NamingConvention}
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.regions.Region
@@ -34,16 +35,30 @@ object Sqs {
     * Provides a resource that uses the values from the
     * config file to acquire and release a [[Sqs]] instance.
     *
-    * The config can be overwritten from an `application.conf` file
-    * present under the `resources` folder. Which it should look like:
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
     * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
     *
-    * @return a [[Resource]] of [[Task]] that acquires and releases [[Sqs]].
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.sqs.Sqs
+    *
+    *   Sqs.fromConfig.use { sqs =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases a [[Sqs]] connection.
     */
+  @deprecated("Use `fromConfig(namingConvention)`", "0.6.1")
   def fromConfig: Resource[Task, Sqs] = {
     Resource.make {
       for {
-        clientConf  <- MonixAwsConf.load
+        clientConf  <- MonixAwsConf.load()
         asyncClient <- Task.now(AsyncClientConversions.fromMonixAwsConf(clientConf))
       } yield asyncClient
     }(asyncClient => Task.evalAsync(asyncClient.close()))
@@ -51,9 +66,110 @@ object Sqs {
   }
 
   /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[Sqs]] instance.
+    *
+    * It does not requires any input parameter as it expect the
+    * aws config to be set from `application.conf`, which has to be
+    * placed under the `resources` folder and will overwrite the
+    * defaults values from:
+    * `https://github.com/monix/monix-connect/blob/master/aws-auth/src/main/resources/reference.conf`.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.sqs.Sqs
+    *
+    *   Sqs.fromConfig.use { sqs =>
+    *      //business logic here
+    *      Task.unit
+    *   }
+    * }}}
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases a [[Sqs]] connection.
+    */
+  def fromConfig(namingConvention: NamingConvention = KebabCase): Resource[Task, Sqs] = {
+    Resource.make {
+      for {
+        clientConf  <- MonixAwsConf.load(namingConvention)
+        asyncClient <- Task.now(AsyncClientConversions.fromMonixAwsConf(clientConf))
+      } yield asyncClient
+    }(asyncClient => Task.evalAsync(asyncClient.close()))
+      .map(this.createUnsafe(_))
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[Sqs]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.connect.sqs.Sqs
+    *   import software.amazon.awssdk.regions.Region
+    *
+    *   MonixAwsConf.load().flatMap{ awsConf =>
+    *       // you can update your config from code too
+    *       val updatedAwsConf = awsConf.copy(region = Region.AP_SOUTH_1)
+    *       Sqs.fromConfig(updatedAwsConf).use { sqs =>
+    *          //business logic here
+    *          Task.unit
+    *       }
+    *   }
+    * }}}
+    *
+    * @param monixAwsConf the monix aws config read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases a [[Sqs]] connection.
+    */
+  def fromConfig(monixAwsConf: MonixAwsConf): Resource[Task, Sqs] = {
+    Resource.make {
+     Task.now(AsyncClientConversions.fromMonixAwsConf(monixAwsConf))
+    }(asyncClient => Task.evalAsync(asyncClient.close()))
+      .map(this.createUnsafe(_))
+  }
+
+  /**
+    * Provides a resource that uses the values from the
+    * config file to acquire and release a [[Sqs]] instance.
+    *
+    * The config will come from [[MonixAwsConf]] which it is
+    * actually obtained from the `application.conf` file present
+    * under the `resources` folder.
+    *
+    * ==Example==
+    * {{{
+    *   import monix.connect.aws.auth.MonixAwsConf
+    *   import monix.eval.Task
+    *   import monix.connect.sqs.Sqs
+    *
+    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   Sqs.fromConfig(awsConf).use { sqs =>
+    *          //business logic here
+    *          Task.unit
+    *    }
+    * }}}
+    *
+    * @param monixAwsConf a task containing the monix aws config
+    *                     read from config file.
+    *
+    * @return a [[Resource]] of [[Task]] that acquires and releases a [[Sqs]] connection.
+    */
+  def fromConfig(monixAwsConf: Task[MonixAwsConf]): Resource[Task, Sqs] = {
+    Resource.make {
+      monixAwsConf.map(AsyncClientConversions.fromMonixAwsConf)
+    }(asyncClient => Task.evalAsync(asyncClient.close()))
+      .map(this.createUnsafe(_))
+  }
+
+  /**
     * Creates a [[Resource]] that using passed-by-parameter
     * AWS configurations, it encodes the acquisition and release
-    * of the resources needed to instantiate the [[S3]].
+    * of the resources needed to instantiate the [[Sqs]].
     *
     * ==Example==
     *
@@ -67,11 +183,11 @@ object Sqs {
     *   val sqsResource: Resource[Task, Sqs] = Sqs.create(defaultCredentials, Region.AWS_GLOBAL)
     * }}}
     *
-    * @param credentialsProvider strategy for loading credentials and authenticate to AWS S3
+    * @param credentialsProvider strategy for loading credentials and authenticate to AWS Sqs
     * @param region              an Amazon Web Services region that hosts a set of Amazon services.
     * @param endpoint            the endpoint with which the SDK should communicate.
     * @param httpClient          sets the [[SdkAsyncHttpClient]] that the SDK service client will use to make HTTP calls.
-    * @return a [[Resource]] of [[Task]] that acquires and releases [[Sqs]] instance.
+    * @return a [[Resource]] of [[Task]] that acquires and releases [[Sqs]] connection.
     */
 
   def create(

--- a/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
@@ -45,6 +45,7 @@ object Sqs {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.sqs.Sqs
+    *   import monix.eval.Task
     *
     *   Sqs.fromConfig.use { sqs =>
     *      //business logic here
@@ -79,6 +80,7 @@ object Sqs {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.sqs.Sqs
+    *   import monix.eval.Task
     *
     *   Sqs.fromConfig.use { sqs =>
     *      //business logic here
@@ -110,6 +112,7 @@ object Sqs {
     * {{{
     *   import monix.connect.aws.auth.MonixAwsConf
     *   import monix.connect.sqs.Sqs
+    *   import monix.eval.Task
     *   import software.amazon.awssdk.regions.Region
     *
     *   MonixAwsConf.load().flatMap{ awsConf =>
@@ -268,6 +271,7 @@ object Sqs {
     *   import monix.execution.Scheduler.Implicits.global
     *   import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
     *   import software.amazon.awssdk.regions.Region
+    *   import monix.eval.Task
     *
     *   val defaultCred = DefaultCredentialsProvider.create()
     *   val sqs: Sqs = Sqs.createUnsafe(defaultCred, Region.AWS_GLOBAL)

--- a/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
+++ b/sqs/src/main/scala/monix/connect/sqs/Sqs.scala
@@ -147,7 +147,7 @@ object Sqs {
     *   import monix.eval.Task
     *   import monix.connect.sqs.Sqs
     *
-    *   val monixAwsConf: Task[MonixAwsConf] = MonixAwsConf.load()
+    *   val awsConf: Task[MonixAwsConf] = MonixAwsConf.load()
     *   Sqs.fromConfig(awsConf).use { sqs =>
     *          //business logic here
     *          Task.unit


### PR DESCRIPTION
Addresses: https://github.com/monix/monix-connect/issues/653 

This PR deprecates the previous `.fromConfig` method that loaded a config from default file without accepting any parameter.

The method has been overloaded to accept three different signatures:

- `fromConfig(namingConvention: NamingConvention)`
- `fromConfig(monixAwsConf: MonixAwsConf)`
- `fromConfig(monixAwsConf: Task[MonixAwsConf])`

These provides to the user, a more flexible way of loading config, in which they are not restricted to using `KebabCase`, which potentially conflict with their existing config. 
Moreover, it also allows to first load the config in the `MonixAwsConf` before actually consuming it, which might makes it more transparent to the user if they want to debug what is actually being loaded in the conf and also to being able to update it from code, whereas with the first method we could not do that.