### PR TITLE
removed leading and trailing bracket to fix merging of reference.conf

### DIFF
--- a/aws-auth/src/main/resources/reference.conf
+++ b/aws-auth/src/main/resources/reference.conf
@@ -1,79 +1,76 @@
-{
 
-  monix-aws: {
+monix-aws: {
 
-    credentials {
+  credentials {
 
-      // Required - Specifies the aws credentials provider
-      // Posible values: [anonymous, default, environment, instance, system, profile, static]
-      provider: "default"
+    // Required - Specifies the aws credentials provider
+    // Posible values: [anonymous, default, environment, instance, system, profile, static]
+    provider: "default"
 
-      // Optional - settings that only applies when `provider` is set to 'static'.
-      //
-      // If that's the case, `acces-key-id` and `secret-access-key` to create basic credentials:
-      // `software.amazon.awssdk.auth.credentials.AwsBasicCredentials`
-      //
-      // On the other hand, if the optional value `secret-access-key` is defined, it will use session credentials:
-      // `software.amazon.awssdk.auth.credentials.SessionStaticCredentialsProvider`
-      // [[https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSSessionCredentials.html]]
-      //
-      # static {
-      #
-      #  // Required - within static settings.
-      #  access-key-id: ""
-      #
-      #  // Required - within static settings.
-      #  secret-access-key: ""
-      #
-      #  // Optional - when defined, will create `SessionStaticCredentialsProvider`
-      #  session-token: ""
-      #
-      # }
-    }
-
-    // Required - Indicates the AWS region, should be in lowercase and use hyphens.
-    // Just like using `software.amazon.awssdk.regions.Region.of(_)`
-    // Examples: [ap-south-1, us-gov-east-1, af-south-1, eu-west-2, aws-global]
-    region: "eu-west-1"
-
-    // Optional - string to overrides endpoint url
-    # endpoint: "localhost:4566"
-
-    // Optional - settings for the underlying async http client
-    # http-client: {
-    #   max-concurrency: 10
-    #   max-pending-connection-acquires: 1000
-    #   connection-acquisition-timeout: 2 minutes
-    #   connection-time-to-live: 1 minute
-    #   use-idle-connection-reaper: false
-    #   read-timeout: 100 seconds
-    #   write-timeout: 100 seconds
+    // Optional - settings that only applies when `provider` is set to 'static'.
+    //
+    // If that's the case, `acces-key-id` and `secret-access-key` to create basic credentials:
+    // `software.amazon.awssdk.auth.credentials.AwsBasicCredentials`
+    //
+    // On the other hand, if the optional value `secret-access-key` is defined, it will use session credentials:
+    // `software.amazon.awssdk.auth.credentials.SessionStaticCredentialsProvider`
+    // [[https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSSessionCredentials.html]]
+    //
+    # static {
+    #
+    #  // Required - within static settings.
+    #  access-key-id: ""
+    #
+    #  // Required - within static settings.
+    #  secret-access-key: ""
+    #
+    #  // Optional - when defined, will create `SessionStaticCredentialsProvider`
+    #  session-token: ""
+    #
     # }
-
   }
 
-  // Camel case fallback
-  monixAws: {
-    credentials {
-      provider: "default"
-    }
-    region: "eu-west-1"
-  }
+  // Required - Indicates the AWS region, should be in lowercase and use hyphens.
+  // Just like using `software.amazon.awssdk.regions.Region.of(_)`
+  // Examples: [ap-south-1, us-gov-east-1, af-south-1, eu-west-2, aws-global]
+  region: "eu-west-1"
 
-  // Snake case fallback
-  monix_aws: {
-    credentials {
-      provider: "default"
-    }
-    region: "eu-west-1"
-  }
+  // Optional - string to overrides endpoint url
+  # endpoint: "localhost:4566"
 
-  // Pascal case fallback
-  MonixAws: {
-    credentials {
-      provider: "default"
-    }
-    region: "eu-west-1"
-  }
+  // Optional - settings for the underlying async http client
+  # http-client: {
+  #   max-concurrency: 10
+  #   max-pending-connection-acquires: 1000
+  #   connection-acquisition-timeout: 2 minutes
+  #   connection-time-to-live: 1 minute
+  #   use-idle-connection-reaper: false
+  #   read-timeout: 100 seconds
+  #   write-timeout: 100 seconds
+  # }
 
+}
+
+// Camel case fallback
+monixAws: {
+  credentials {
+    provider: "default"
+  }
+  region: "eu-west-1"
+}
+
+// Snake case fallback
+monix_aws: {
+  credentials {
+    provider: "default"
+  }
+  region: "eu-west-1"
+}
+
+// Pascal case fallback
+MonixAws: {
+  credentials {
+    provider: "default"
+  }
+  region: "eu-west-1"
 }


### PR DESCRIPTION
```
{
 mysettings
}
```

will end up as an invalid config after a fat jar is generated. 

```
appsettings
{
 mysettings
}

othersettings:
```