### PR TITLE
Sets min part number on s3MultopartUpload to 1 (#814)

### DIFF
--- a/s3/src/main/scala/monix/connect/s3/MultipartUploadSubscriber.scala
+++ b/s3/src/main/scala/monix/connect/s3/MultipartUploadSubscriber.scala
@@ -76,7 +76,7 @@ private[s3] class MultipartUploadSubscriber(
 
       private[this] var buffer: Array[Byte] = Array.emptyByteArray
       private[this] var completedParts: List[CompletedPart] = List.empty[CompletedPart]
-      private[this] val partNMVarEval: Task[MVar[Task, Int]] = MVar[Task].of(0).memoize
+      private[this] val partNMVarEval: Task[MVar[Task, Int]] = MVar[Task].of(1).memoize
 
       /**
         * If the chunk length is bigger than the minimum size, perfom the part request [[software.amazon.awssdk.services.s3.model.UploadPartRequest]],


### PR DESCRIPTION
Sets the minimum value to 1 on the s3 multipart upload operation. 
As per following the aws requirements indicated in the docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html