### PR TITLE
Fix offset overflow in multipart download

### DIFF
--- a/s3/src/main/scala/monix/connect/s3/MultipartDownloadObservable.scala
+++ b/s3/src/main/scala/monix/connect/s3/MultipartDownloadObservable.scala
@@ -64,7 +64,7 @@ private[s3] class MultipartDownloadObservable(
     totalSize: Long,
     chunkSize: Long,
     getRequest: GetObjectRequest,
-    offset: Int): Task[Unit] = {
+    offset: Long): Task[Unit] = {
 
     for {
       chunk <- {
@@ -77,7 +77,7 @@ private[s3] class MultipartDownloadObservable(
       nextChunk <- {
         ack match {
           case Ack.Continue => {
-            val nextOffset = offset + chunk.size
+            val nextOffset = offset + chunk.length
             if (nextOffset < totalSize) {
               val nextRange = s"bytes=${nextOffset}-${nextOffset + chunkSize}"
               val nextRequest = getRequest.toBuilder.range(nextRange).build()


### PR DESCRIPTION
Hi, we have found that the offset overflow causes file content corruption or OOM when attempting to download files larger than approximately 2 GB.