### PR TITLE
Removes akka connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,10 +163,8 @@ lazy val monixConnect = (project in file("."))
   .configs(IntegrationTest, IT)
   .settings(sharedSettings())
   .settings(name := "monix-connect")
-  .aggregate(akka, dynamodb, parquet, gcs, hdfs, mongodb, redis, s3, sqs, elasticsearch, awsAuth)
-  .dependsOn(akka, dynamodb, parquet, gcs, hdfs, mongodb, redis, s3, sqs, elasticsearch, awsAuth)
-
-lazy val akka = monixConnector("akka", Dependencies.Akka)
+  .aggregate(dynamodb, parquet, gcs, hdfs, mongodb, redis, s3, sqs, elasticsearch, awsAuth)
+  .dependsOn(dynamodb, parquet, gcs, hdfs, mongodb, redis, s3, sqs, elasticsearch, awsAuth)
 
 lazy val dynamodb = monixConnector("dynamodb", Dependencies.DynamoDb).aggregate(awsAuth).dependsOn(awsAuth % "compile->compile;test->test")
   .settings(libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -276,7 +274,7 @@ lazy val skipOnPublishSettings = Seq(
 lazy val mdocSettings = Seq(
   scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused"),
   crossScalaVersions := Seq(scalaVersion.value),
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(akka, parquet, dynamodb, s3, sqs, elasticsearch, gcs, hdfs, mongodb, redis),
+  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(parquet, dynamodb, s3, sqs, elasticsearch, gcs, hdfs, mongodb, redis),
   target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",
   cleanFiles += (target in (ScalaUnidoc, unidoc)).value,
   docusaurusCreateSite := docusaurusCreateSite

--- a/docs/dynamo.md
+++ b/docs/dynamo.md
@@ -23,7 +23,7 @@ Therefore, the connector provides three generic methods __single__, __transforme
 
 Add the following dependency to get started:
 ```scala 
-libraryDependencies += "io.monix" %% "monix-dynamodb" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-dynamodb" % "0.9.0"
 ```
 
 ## Async Client

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -15,7 +15,7 @@ but also to _search_ or _upload_ in a reactive fashion with _Monix Reactive_.
  Add the following dependency:
  
  ```scala
- libraryDependencies += "io.monix" %% "monix-elasticsearch" % "0.6.0"
+ libraryDependencies += "io.monix" %% "monix-elasticsearch" % "0.9.0"
  ```
  
 ## Client

--- a/docs/gcs.md
+++ b/docs/gcs.md
@@ -14,7 +14,7 @@ object will be returned to any _get request_, globally.
 
 Add the following dependency to get started:
 ```scala
-libraryDependencies += "io.monix" %% "monix-gcs" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-gcs" % "0.9.0"
 ```
 
 ## Getting Started

--- a/docs/hdfs.md
+++ b/docs/hdfs.md
@@ -18,7 +18,7 @@ and it is built on top of the the official _apache hadoop_ api.
 Add the following dependency to get started:
 
 ```scala 
-libraryDependencies += "io.monix" %% "monix-hdfs" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-hdfs" % "0.9.0"
 ```
 
 By default the connector uses _Hadoop 3.1.1_. In case you need a different one you can replace it by excluding `org.apache.hadoop` from `monix-hdfs` and add the new one to your library dependencies.

--- a/docs/mongodb.md
+++ b/docs/mongodb.md
@@ -29,7 +29,7 @@ and there is many code to be ported to the new Scala3 macros. See community stat
 Add the following dependency to get started:
 
 ```scala
-libraryDependencies += "io.monix" %% "monix-mongodb" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-mongodb" % "0.9.0"
 ```
 
 ## Collection Reference

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,7 +18,7 @@ title: Overview
 Find all release [versions](https://github.com/monix/monix-connect/releases)).
  
  ```scala   
- libraryDependencies += "io.monix" %% "monix-connect" % "0.9.0"
+ libraryDependencies += "io.monix" %% "monix-connect" % "0.10.0"
 ```
 
 ⚠️ **Mind that the project isn't yet stable, so binary compatibility is not guaranteed.** ❗

--- a/docs/parquet.md
+++ b/docs/parquet.md
@@ -15,7 +15,7 @@ Therefore, the `monix-parquet` _connector_ basically exposes stream integrations
 Add the following dependency:
  
  ```scala
- libraryDependencies += "io.monix" %% "monix-parquet" % "0.6.0"
+ libraryDependencies += "io.monix" %% "monix-parquet" % "0.9.0"
  ```
 
 ## Getting started

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -19,7 +19,7 @@ a _non blocking_ Redis client.
 Add the following dependency:
 
 ```scala
-libraryDependencies += "io.monix" %% "monix-redis" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-redis" % "0.9.0"
 ```
 
 ## Redis Connection

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -16,7 +16,7 @@ This module exposes a wide range of methods for interacting with S3 _buckets_ an
  Add the following dependency in your _build.sbt_:
  
  ```scala
- libraryDependencies += "io.monix" %% "monix-s3" % "0.6.0"
+ libraryDependencies += "io.monix" %% "monix-s3" % "0.9.0"
  ```
  
 ## Async Client

--- a/docs/sqs.md
+++ b/docs/sqs.md
@@ -15,7 +15,7 @@ used as a message broker to communicate different systems, providing backpressur
 
 Add the following dependency to get started:
 ```scala 
-libraryDependencies += "io.monix" %% "monix-sqs" % "0.6.0"
+libraryDependencies += "io.monix" %% "monix-sqs" % "0.9.0"
 ```
 
 ## Async Client

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,8 +40,6 @@ object Dependencies {
     "io.monix" %% "monix-testing-scalatest" % Versions.MonixTestingScalatest
   )
 
-  val Akka = Seq("com.typesafe.akka" %% "akka-stream" % Versions.AkkaStreams) ++ commonDependencies(hasIt = false)
-
   val AwsAuth = Seq(
     "software.amazon.awssdk"                     % "auth" % Versions.AwsSdk,
     "com.github.pureconfig" %% "pureconfig-core" % Versions.Pureconfig) ++ commonDependencies(hasIt = false)


### PR DESCRIPTION
The Akka connector was deprecated since `0.5.x`, we are no longer interested in supporting it so it's being removed.